### PR TITLE
assert_owned_by_or_owned_by (hydra or sysprog) for wallet addmmember

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG.md
 
+## 0.2.2 (2022-03-25) - Unstable release API MAY CHANGE in a future release
+
+Features:
+
+- Allow wallet member to be a hydra wallet
+
 ## 0.2.1 (2022-03-25) - Unstable release API MAY CHANGE in a future release
 
 Fixes:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1302,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "hydra_wallet"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/programs/hydra/Cargo.toml
+++ b/programs/hydra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydra_wallet"
-version = "0.2.1"
+version = "0.2.2"
 description = "Collective account pooling, fan out wallet, dao treasury, all of the things you need to FAN OUT"
 edition = "2018"
 license = "GPL-3.0"

--- a/programs/hydra/src/processors/add_member/wallet.rs
+++ b/programs/hydra/src/processors/add_member/wallet.rs
@@ -1,7 +1,7 @@
 use super::arg::AddMemberArgs;
 use crate::state::{Fanout, FanoutMembershipVoucher, FANOUT_MEMBERSHIP_VOUCHER_SIZE};
 use crate::utils::logic::calculation::*;
-use crate::utils::validation::{assert_membership_model, assert_owned_by};
+use crate::utils::validation::{assert_membership_model, assert_owned_by, assert_owned_by_or_owned_by};
 use crate::MembershipModel;
 use anchor_lang::prelude::*;
 use anchor_spl::token::Token;
@@ -40,7 +40,8 @@ pub fn add_member_wallet(ctx: Context<AddMemberWallet>, args: AddMemberArgs) -> 
     update_fanout_for_add(fanout, args.shares)?;
     assert_membership_model(fanout, MembershipModel::Wallet)?;
     assert_owned_by(&fanout.to_account_info(), &crate::ID)?;
-    assert_owned_by(&member.to_account_info(), &System::id())?;
+    assert_owned_by_or_owned_by(&member.to_account_info(), &System::id(),  &crate::ID)?;
+    
     membership_account.membership_key = member.key();
     membership_account.shares = args.shares;
     membership_account.bump_seed = *ctx.bumps.get("membership_account").unwrap();

--- a/programs/hydra/src/processors/add_member/wallet.rs
+++ b/programs/hydra/src/processors/add_member/wallet.rs
@@ -1,7 +1,11 @@
 use super::arg::AddMemberArgs;
 use crate::state::{Fanout, FanoutMembershipVoucher, FANOUT_MEMBERSHIP_VOUCHER_SIZE};
 use crate::utils::logic::calculation::*;
+<<<<<<< Updated upstream
 use crate::utils::validation::{assert_membership_model, assert_owned_by, assert_owned_by_or_owned_by};
+=======
+use crate::utils::validation::{assert_membership_model, assert_owned_by, assert_owned_by_one};
+>>>>>>> Stashed changes
 use crate::MembershipModel;
 use anchor_lang::prelude::*;
 use anchor_spl::token::Token;
@@ -40,8 +44,8 @@ pub fn add_member_wallet(ctx: Context<AddMemberWallet>, args: AddMemberArgs) -> 
     update_fanout_for_add(fanout, args.shares)?;
     assert_membership_model(fanout, MembershipModel::Wallet)?;
     assert_owned_by(&fanout.to_account_info(), &crate::ID)?;
-    assert_owned_by_or_owned_by(&member.to_account_info(), &System::id(),  &crate::ID)?;
-    
+    assert_owned_by_one(&member.to_account_info(), vec![&System::id(), &crate::ID])?;
+
     membership_account.membership_key = member.key();
     membership_account.shares = args.shares;
     membership_account.bump_seed = *ctx.bumps.get("membership_account").unwrap();

--- a/programs/hydra/src/utils/validation/mod.rs
+++ b/programs/hydra/src/utils/validation/mod.rs
@@ -32,6 +32,14 @@ pub fn assert_owned_by(account: &AccountInfo, owner: &Pubkey) -> ProgramResult {
     }
 }
 
+pub fn assert_owned_by_or_owned_by(account: &AccountInfo, owner: &Pubkey, or_owner: &Pubkey) -> ProgramResult {
+    if account.owner != owner || account.owner != or_owner {
+        Err(ErrorCode::IncorrectOwner.into())
+    } else {
+        Ok(())
+    }
+}
+
 pub fn assert_membership_model(
     fanout: &Account<Fanout>,
     model: MembershipModel,


### PR DESCRIPTION
hi,

I believe this is aligned and has minimal # files changed :)

naming conventions be damned if you want change my feeble attempts to name stuff

btw this is a bit time sensitive, there's a thing where someone wants

1. nfts
2. going to wallet hydra
3. this pays a few wallies
4. notably some are going to be hydras
5. monye