### PR TITLE
Remove is_native constraint

### DIFF
--- a/programs/hydra/src/processors/init/init_for_mint.rs
+++ b/programs/hydra/src/processors/init/init_for_mint.rs
@@ -29,7 +29,6 @@ pub struct InitializeFanoutForMint<'info> {
     constraint = mint_holding_account.owner == fanout.key(),
     constraint = mint_holding_account.delegate.is_none(),
     constraint = mint_holding_account.close_authority.is_none(),
-    constraint = mint_holding_account.is_native() == false,
     constraint = mint_holding_account.mint == mint.key(),
     )
     ]


### PR DESCRIPTION
Per discussion here https://github.com/GlassEaters/hydra/issues/29

@TheCurryMan and I see no issues with this change and it should simply allow for using wSOL if desired